### PR TITLE
chore(exposure): remove timeout on adjusting exposure

### DIFF
--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -45,8 +45,6 @@
 @property(nonatomic, assign) BOOL canAppendBuffer;
 @property(nonatomic, assign) CMTime bufferTimestamp;
 @property(nonatomic, assign) Float64 maxDuration;
-@property(nonatomic, assign) BOOL exposureTimeout;
-@property (nonatomic, strong) NSTimer *exposureTimer;
 
 - (id)initWithBridge:(RCTBridge *)bridge;
 - (void)updateType;

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -463,7 +463,9 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 
 - (void)captureOutput:(AVCaptureOutput *)output didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer fromConnection:(AVCaptureConnection *)connection
 {
-    [self findPrimaryFace:sampleBuffer];
+    if (@available(iOS 11, *)) {
+        [self findPrimaryFace:sampleBuffer];
+    }
 
     if (self.canAppendBuffer) {
         if (self.videoWriter.status != AVAssetWriterStatusWriting) {
@@ -477,7 +479,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     }
 }
 
--(void)findPrimaryFace:(CMSampleBufferRef)sampleBuffer {
+-(void)findPrimaryFace:(CMSampleBufferRef)sampleBuffer API_AVAILABLE(ios(11.0)) {
     CVPixelBufferRef pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
     CIImage *image = [CIImage imageWithCVPixelBuffer:pixelBuffer];
     CIImage *orientedImage = [image imageByApplyingCGOrientation:kCGImagePropertyOrientationUpMirrored];
@@ -488,51 +490,38 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     [handler performRequests:@[faceDetectionReq] error:nil];
 
     VNFaceObservation *primaryFace;
-    CGPoint primaryFaceCenter;
-    float primaryFaceSize;
+    CGPoint primaryFaceCenter = CGPointZero;
+    float primaryFaceSize = 0;
 
-    for(VNFaceObservation *observation in faceDetectionReq.results){
-        if(observation){
-            float size = observation.boundingBox.size.height * observation.boundingBox.size.width;
-            if (!primaryFace || size > primaryFaceSize) {
-                primaryFace = observation;
-                primaryFaceCenter = CGPointMake(CGRectGetMidX(observation.boundingBox), CGRectGetMidY(observation.boundingBox));
-                primaryFaceSize = size;
-            }
+    for (VNFaceObservation *observation in faceDetectionReq.results) {
+        if (!observation) continue;
+        float size = observation.boundingBox.size.height * observation.boundingBox.size.width;
+        if (!primaryFace || size > primaryFaceSize) {
+            primaryFace = observation;
+            primaryFaceCenter = CGPointMake(CGRectGetMidX(observation.boundingBox), CGRectGetMidY(observation.boundingBox));
+            primaryFaceSize = size;
         }
     }
 
-    if ([faceDetectionReq.results count]) {
-        [self setExposure:primaryFaceCenter];
-    }
+    if (![faceDetectionReq.results count] || CGPointEqualToPoint(primaryFaceCenter, CGPointZero)) return;
+    dispatch_sync(dispatch_get_main_queue(), ^() {
+        CGPoint scaledPoint = CGPointMake(primaryFaceCenter.x * self.layer.bounds.size.width, (1-primaryFaceCenter.y) * self.layer.bounds.size.height);
+        CGPoint devicePoint = [self.previewLayer captureDevicePointOfInterestForPoint:scaledPoint];
+        [self setExposureAtPoint:devicePoint];
+    });
 }
 
-- (void)resetExposureTimeout;
+- (void)setExposureAtPoint:(CGPoint)point
 {
-    self.exposureTimeout = NO;
-}
-
-- (void)setExposure:(CGPoint) point;
-{
-    if (self.exposureTimeout) {
+    AVCaptureDevice *device = [self.videoCaptureDeviceInput device];
+    NSError *error = nil;
+    if (![device lockForConfiguration:&error]) {
+        RCTLogError(@"%s: %@", __func__, error);
         return;
     }
-    AVCaptureDevice *device = [self.videoCaptureDeviceInput device];
-    [device lockForConfiguration:nil];
-    CGPoint scaledPoint = CGPointMake(point.x * self.layer.bounds.size.width, (1-point.y) * self.layer.bounds.size.height);
-    CGPoint devicePoint = [self.previewLayer captureDevicePointOfInterestForPoint:scaledPoint];
-    [device setExposurePointOfInterest:devicePoint];
-    if ([device isExposureModeSupported:AVCaptureExposureModeContinuousAutoExposure])
-    {
-        [device setExposureMode:AVCaptureExposureModeContinuousAutoExposure];
-    }
-    [device setWhiteBalanceMode:AVCaptureWhiteBalanceModeContinuousAutoWhiteBalance];
-    [device unlockForConfiguration];
 
-    self.exposureTimeout = YES;
-    dispatch_async(dispatch_get_main_queue(), ^{
-        self.exposureTimer = [NSTimer scheduledTimerWithTimeInterval:1.0 target:self selector:@selector(resetExposureTimeout) userInfo:nil repeats:NO];
-    });
+    [device setExposurePointOfInterest:point];
+    [device unlockForConfiguration];
 }
 
 
@@ -546,7 +535,6 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     //        [self onMountingError:@{@"message": @"Camera permissions not granted - component could not be rendered."}];
     //        return;
     //    }
-    self.exposureTimeout = NO;
     self.canAppendBuffer = NO;
 
     dispatch_async(self.sessionQueue, ^{


### PR DESCRIPTION
Removes the timeout so that focus is constantly adjusted when faces are detected.

A couple other minor tweaks:

- Seeing some compiler warnings around variables not being instantiated before being used so added a default state for both the face size and the face center point
- These APIs are only available in iOS 11 so added a guard that will prevent them from crashing on an older iOS version.
- When converting to the device point I was getting errors in the logs around `[self layer]` needing to be run on the main thread, so I added a dispatch to silent these.

Make sure I didn't break anything obvious :)