### PR TITLE
refactor(video): remove animation and consolidate callbacks

### DIFF
--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -34,15 +34,10 @@
 @property(nonatomic, assign, getter=isReadingBarCodes) BOOL barCodeReading;
 @property(nonatomic, assign) AVVideoCodecType videoCodecType;
 
-@property(nonatomic, assign) CGSize animationOutputSize;
-@property(nonatomic, assign) int64_t animationInputFps;
-@property(nonatomic, assign) int64_t animationOutputFps;
-
 @property(nonatomic, strong) dispatch_queue_t frameBufferQueue;
 @property(nonatomic, strong) AVAssetWriter *videoWriter;
 @property(nonatomic, strong) AVAssetWriterInput* writerInput;
 @property(nonatomic, strong) AVCaptureVideoDataOutput* videoOutput;
-@property(nonatomic, strong) NSTimer* maxDurationTimer;
 @property(nonatomic, assign) BOOL canAppendBuffer;
 @property(nonatomic, assign) CMTime bufferTimestamp;
 @property(nonatomic, assign) Float64 maxDuration;
@@ -67,8 +62,6 @@
 - (void)onMountingError:(NSDictionary *)event;
 - (void)onCodeRead:(NSDictionary *)event;
 - (void)onFacesDetected:(NSDictionary *)event;
-
-- (void)processVideoToAnimation:(NSURL *)outputFileURL;
 - (void)stopAssetWriter;
 
 @end

--- a/ios/RN/RNCameraUtils.h
+++ b/ios/RN/RNCameraUtils.h
@@ -16,8 +16,8 @@
 // Enum conversions
 + (float)temperatureForWhiteBalance:(RNCameraWhiteBalance)whiteBalance;
 + (NSString *)captureSessionPresetForVideoResolution:(RNCameraVideoResolution)resolution;
-+ (AVCaptureVideoOrientation)videoOrientationForDeviceOrientation:(UIDeviceOrientation)orientation;
 + (AVCaptureVideoOrientation)videoOrientationForInterfaceOrientation:(UIInterfaceOrientation)orientation;
++ (CGAffineTransform)videoTransformForOrientation:(UIInterfaceOrientation)orientation;
 
 @end
 

--- a/ios/RN/RNCameraUtils.m
+++ b/ios/RN/RNCameraUtils.m
@@ -44,19 +44,19 @@
     }
 }
 
-+ (AVCaptureVideoOrientation)videoOrientationForDeviceOrientation:(UIDeviceOrientation)orientation
++ (CGAffineTransform)videoTransformForOrientation:(UIInterfaceOrientation)orientation
 {
     switch (orientation) {
-        case UIDeviceOrientationPortrait:
-            return AVCaptureVideoOrientationPortrait;
-        case UIDeviceOrientationPortraitUpsideDown:
-            return AVCaptureVideoOrientationPortraitUpsideDown;
-        case UIDeviceOrientationLandscapeLeft:
-            return AVCaptureVideoOrientationLandscapeRight;
-        case UIDeviceOrientationLandscapeRight:
-            return AVCaptureVideoOrientationLandscapeLeft;
+        case UIInterfaceOrientationPortrait:
+            return CGAffineTransformMakeRotation(( 90 * M_PI ) / 180);
+        case UIInterfaceOrientationPortraitUpsideDown:
+            return CGAffineTransformMakeRotation(( -90 * M_PI ) / 180);
+        case UIInterfaceOrientationLandscapeLeft:
+            return CGAffineTransformMakeRotation(( -180 * M_PI ) / 180);
+        case UIInterfaceOrientationLandscapeRight:
+            return CGAffineTransformMakeRotation(0 / 180);
         default:
-            return AVCaptureVideoOrientationPortrait;
+            return CGAffineTransformMakeRotation(0 / 180);
     }
 }
 


### PR DESCRIPTION
There's quite a bit here and this should fix some of the overall stability issues where the camera will sometimes fail to record or fail to stop recording after it's started.

Of note:

- Animation creator is gone and part of photomadic/capture-kit now. There were a few bugs with the conversion process but overall this keeps the project less complex and closer to upstream which will help with ongoing maintenance.

- Refactored some configuration calls including removing multiple calls to setup the video recording. Changed a few configuration lines which seem to help with the camera recording black frames intermittently including `recommendedVideoSettingsForAssetWriterWithOutputFileType` and `kCVPixelBufferPixelFormatTypeKey`

- Moved the promise/reject calls back into the `record` function. I think there was something going on here where ARC was deallocating something before these were called, although I'm not 100% this helped my sanity in debugging so I'm leaving it for now.