### PR TITLE
fix(exposure): set correct orientation facial tracking on front or back camera

### DIFF
--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -42,6 +42,7 @@
 @property(nonatomic, assign) CMTime bufferTimestamp;
 @property(nonatomic, assign) Float64 maxDuration;
 @property(nonatomic, assign) CGPoint primaryFaceCenter;
+@property(nonatomic, assign) CGImagePropertyOrientation facialTrackingOrientation;
 
 - (id)initWithBridge:(RCTBridge *)bridge;
 - (void)updateType;

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -564,7 +564,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     //        return;
     //    }
     self.canAppendBuffer = NO;
-    self.facialTrackingOrientation = [RNCameraUtils imageOrientationForFacialTracking:[[UIApplication sharedApplication] statusBarOrientation]:[self.videoCaptureDeviceInput device].position];
+    self.facialTrackingOrientation = [RNCameraUtils imageOrientationForInterfaceOrientation:[[UIApplication sharedApplication] statusBarOrientation] withDevicePosition:[self.videoCaptureDeviceInput device].position];
 
     dispatch_async(self.sessionQueue, ^{
         if (self.presetCamera == AVCaptureDevicePositionUnspecified) {
@@ -758,7 +758,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 {
     __weak typeof(self) weakSelf = self;
     AVCaptureVideoOrientation videoOrientation = [RNCameraUtils videoOrientationForInterfaceOrientation:orientation];
-    self.facialTrackingOrientation = [RNCameraUtils imageOrientationForFacialTracking:[[UIApplication sharedApplication] statusBarOrientation]:[self.videoCaptureDeviceInput device].position];
+    self.facialTrackingOrientation = [RNCameraUtils imageOrientationForInterfaceOrientation:[[UIApplication sharedApplication] statusBarOrientation] withDevicePosition:[self.videoCaptureDeviceInput device].position];
     dispatch_async(dispatch_get_main_queue(), ^{
         __strong typeof(self) strongSelf = weakSelf;
         if (strongSelf && strongSelf.previewLayer.connection.isVideoOrientationSupported) {

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -485,7 +485,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 -(void)findPrimaryFace:(CMSampleBufferRef)sampleBuffer API_AVAILABLE(ios(11.0)) {
     CVPixelBufferRef pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
     CIImage *image = [CIImage imageWithCVPixelBuffer:pixelBuffer];
-    CIImage *orientedImage = [image imageByApplyingCGOrientation:kCGImagePropertyOrientationUpMirrored];
+    CIImage *orientedImage = [image imageByApplyingCGOrientation:self.facialTrackingOrientation];
 
     VNDetectFaceRectanglesRequest *faceDetectionReq = [VNDetectFaceRectanglesRequest new];
     NSDictionary *d = [[NSDictionary alloc] init];
@@ -496,6 +496,8 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
         self.primaryFaceCenter = CGPointZero;
         return;
     };
+
+    NSLog(@"---found face");
 
     if (!self.canAppendBuffer || (self.canAppendBuffer && CGPointEqualToPoint(self.primaryFaceCenter, CGPointZero))) {
         [self establishPrimaryFace:faceDetectionReq];
@@ -564,6 +566,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     //        return;
     //    }
     self.canAppendBuffer = NO;
+    self.facialTrackingOrientation = [RNCameraUtils imageOrientationForFacialTracking:[[UIApplication sharedApplication] statusBarOrientation]:[self.videoCaptureDeviceInput device].position];
 
     dispatch_async(self.sessionQueue, ^{
         if (self.presetCamera == AVCaptureDevicePositionUnspecified) {
@@ -757,6 +760,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 {
     __weak typeof(self) weakSelf = self;
     AVCaptureVideoOrientation videoOrientation = [RNCameraUtils videoOrientationForInterfaceOrientation:orientation];
+    self.facialTrackingOrientation = [RNCameraUtils imageOrientationForFacialTracking:[[UIApplication sharedApplication] statusBarOrientation]:[self.videoCaptureDeviceInput device].position];
     dispatch_async(dispatch_get_main_queue(), ^{
         __strong typeof(self) strongSelf = weakSelf;
         if (strongSelf && strongSelf.previewLayer.connection.isVideoOrientationSupported) {

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -497,8 +497,6 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
         return;
     };
 
-    NSLog(@"---found face");
-
     if (!self.canAppendBuffer || (self.canAppendBuffer && CGPointEqualToPoint(self.primaryFaceCenter, CGPointZero))) {
         [self establishPrimaryFace:faceDetectionReq];
     } else {

--- a/ios/RN/RNCameraUtils.h
+++ b/ios/RN/RNCameraUtils.h
@@ -18,6 +18,6 @@
 + (NSString *)captureSessionPresetForVideoResolution:(RNCameraVideoResolution)resolution;
 + (AVCaptureVideoOrientation)videoOrientationForInterfaceOrientation:(UIInterfaceOrientation)orientation;
 + (CGAffineTransform)videoTransformForOrientation:(UIInterfaceOrientation)orientation;
-+ (CGImagePropertyOrientation)imageOrientationForFacialTracking:(UIInterfaceOrientation)orientation :(AVCaptureDevicePosition)camera;
++ (CGImagePropertyOrientation)imageOrientationForInterfaceOrientation:(UIInterfaceOrientation)orientation withDevicePosition:(AVCaptureDevicePosition)position;
 
 @end

--- a/ios/RN/RNCameraUtils.h
+++ b/ios/RN/RNCameraUtils.h
@@ -18,6 +18,6 @@
 + (NSString *)captureSessionPresetForVideoResolution:(RNCameraVideoResolution)resolution;
 + (AVCaptureVideoOrientation)videoOrientationForInterfaceOrientation:(UIInterfaceOrientation)orientation;
 + (CGAffineTransform)videoTransformForOrientation:(UIInterfaceOrientation)orientation;
++ (CGImagePropertyOrientation)imageOrientationForFacialTracking:(UIInterfaceOrientation)orientation :(AVCaptureDevicePosition)camera;
 
 @end
-

--- a/ios/RN/RNCameraUtils.m
+++ b/ios/RN/RNCameraUtils.m
@@ -60,9 +60,9 @@
     }
 }
 
-+ (CGImagePropertyOrientation)imageOrientationForFacialTracking:(UIInterfaceOrientation)orientation :(AVCaptureDevicePosition)camera
++ (CGImagePropertyOrientation)imageOrientationForInterfaceOrientation:(UIInterfaceOrientation)orientation withDevicePosition:(AVCaptureDevicePosition)position
 {
-    if (camera == AVCaptureDevicePositionFront) {
+    if (position == AVCaptureDevicePositionFront) {
         switch (orientation) {
             case UIInterfaceOrientationPortrait:
                 return kCGImagePropertyOrientationLeftMirrored;

--- a/ios/RN/RNCameraUtils.m
+++ b/ios/RN/RNCameraUtils.m
@@ -90,8 +90,6 @@
     }
 }
 
-
-
 + (float)temperatureForWhiteBalance:(RNCameraWhiteBalance)whiteBalance
 {
     switch (whiteBalance) {

--- a/ios/RN/RNCameraUtils.m
+++ b/ios/RN/RNCameraUtils.m
@@ -15,14 +15,14 @@
 {
     NSArray *devices = [AVCaptureDevice devicesWithMediaType:mediaType];
     AVCaptureDevice *captureDevice = [devices firstObject];
-    
+
     for (AVCaptureDevice *device in devices) {
         if ([device position] == position) {
             captureDevice = device;
             break;
         }
     }
-    
+
     return captureDevice;
 }
 
@@ -60,6 +60,38 @@
     }
 }
 
++ (CGImagePropertyOrientation)imageOrientationForFacialTracking:(UIInterfaceOrientation)orientation :(AVCaptureDevicePosition)camera
+{
+    if (camera == AVCaptureDevicePositionFront) {
+        switch (orientation) {
+            case UIInterfaceOrientationPortrait:
+                return kCGImagePropertyOrientationLeftMirrored;
+            case UIInterfaceOrientationPortraitUpsideDown:
+                return kCGImagePropertyOrientationRightMirrored;
+            case UIInterfaceOrientationLandscapeLeft:
+                return kCGImagePropertyOrientationUpMirrored;
+            case UIInterfaceOrientationLandscapeRight:
+                return kCGImagePropertyOrientationDownMirrored;
+            default:
+                return 0;
+        }
+    }
+    switch (orientation) {
+        case UIInterfaceOrientationPortrait:
+            return kCGImagePropertyOrientationRight;
+        case UIInterfaceOrientationPortraitUpsideDown:
+            return kCGImagePropertyOrientationLeft;
+        case UIInterfaceOrientationLandscapeLeft:
+            return kCGImagePropertyOrientationDown;
+        case UIInterfaceOrientationLandscapeRight:
+            return kCGImagePropertyOrientationUp;
+        default:
+            return 0;
+    }
+}
+
+
+
 + (float)temperatureForWhiteBalance:(RNCameraWhiteBalance)whiteBalance
 {
     switch (whiteBalance) {
@@ -95,4 +127,3 @@
 }
 
 @end
-


### PR DESCRIPTION
Ok...this should bring back the facial metering as we intended to have for the last update. This adds support for tracking at all orientations for both the front and back camera. I've tested on both wave and roam and everything seems to be working as expected.