### PR TITLE
chore(tracking): provide debug option for square around primary face

### DIFF
--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -43,7 +43,6 @@
 @property(nonatomic, assign) CMTime bufferTimestamp;
 @property(nonatomic, assign) Float64 maxDuration;
 @property(nonatomic, assign) CGPoint primaryFaceCenter;
-@property(nonatomic, assign) BOOL enableTrackingRectangle;
 @property (nonatomic, strong) CAShapeLayer *faceRect;
 @property (nonatomic, strong) CAShapeLayer *exposureSquare;
 @property (nonatomic, strong) VNFaceObservation *mainFace;

--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -43,6 +43,7 @@
 @property(nonatomic, assign) CMTime bufferTimestamp;
 @property(nonatomic, assign) Float64 maxDuration;
 @property(nonatomic, assign) CGPoint primaryFaceCenter;
+@property(nonatomic, assign) BOOL enableTrackingRectangle;
 @property (nonatomic, strong) CAShapeLayer *faceRect;
 @property (nonatomic, strong) CAShapeLayer *exposureSquare;
 @property (nonatomic, strong) VNFaceObservation *mainFace;

--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -2,6 +2,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTBridgeModule.h>
 #import <UIKit/UIKit.h>
+#import <Vision/Vision.h>
 
 #if __has_include("RNFaceDetectorManager.h")
 #import "RNFaceDetectorManager.h"
@@ -42,6 +43,9 @@
 @property(nonatomic, assign) CMTime bufferTimestamp;
 @property(nonatomic, assign) Float64 maxDuration;
 @property(nonatomic, assign) CGPoint primaryFaceCenter;
+@property (nonatomic, strong) CAShapeLayer *faceRect;
+@property (nonatomic, strong) CAShapeLayer *exposureSquare;
+@property (nonatomic, strong) VNFaceObservation *mainFace;
 
 - (id)initWithBridge:(RCTBridge *)bridge;
 - (void)updateType;

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -587,7 +587,6 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     //        return;
     //    }
     self.canAppendBuffer = NO;
-    self.enableTrackingRectangle = NO;
 
     dispatch_async(self.sessionQueue, ^{
         if (self.presetCamera == AVCaptureDevicePositionUnspecified) {

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -506,7 +506,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     dispatch_sync(dispatch_get_main_queue(), ^() {
         CGPoint scaledPoint = CGPointMake(self.primaryFaceCenter.x * self.layer.bounds.size.width, (1-self.primaryFaceCenter.y) * self.layer.bounds.size.height);
         CGPoint devicePoint = [self.previewLayer captureDevicePointOfInterestForPoint:scaledPoint];
-        [self drawFaceRect:self.mainFace];
+        if (self.enableTrackingRectangle) [self drawFaceRect:self.mainFace];
         [self setExposureAtPoint:devicePoint];
     });
 }
@@ -585,6 +585,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     //        return;
     //    }
     self.canAppendBuffer = NO;
+    self.enableTrackingRectangle = NO;
 
     dispatch_async(self.sessionQueue, ^{
         if (self.presetCamera == AVCaptureDevicePositionUnspecified) {

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -506,7 +506,9 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     dispatch_sync(dispatch_get_main_queue(), ^() {
         CGPoint scaledPoint = CGPointMake(self.primaryFaceCenter.x * self.layer.bounds.size.width, (1-self.primaryFaceCenter.y) * self.layer.bounds.size.height);
         CGPoint devicePoint = [self.previewLayer captureDevicePointOfInterestForPoint:scaledPoint];
-        if (self.enableTrackingRectangle) [self drawFaceRect:self.mainFace];
+        #ifdef DEBUG
+          [self drawFaceRect:self.mainFace];
+        #endif
         [self setExposureAtPoint:devicePoint];
     });
 }

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -485,7 +485,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 -(void)findPrimaryFace:(CMSampleBufferRef)sampleBuffer API_AVAILABLE(ios(11.0)) {
     CVPixelBufferRef pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
     CIImage *image = [CIImage imageWithCVPixelBuffer:pixelBuffer];
-    CIImage *orientedImage = [image imageByApplyingCGOrientation:kCGImagePropertyOrientationLeftMirrored];
+    CIImage *orientedImage = [image imageByApplyingCGOrientation:kCGImagePropertyOrientationUpMirrored];
 
     VNDetectFaceRectanglesRequest *faceDetectionReq = [VNDetectFaceRectanglesRequest new];
     NSDictionary *d = [[NSDictionary alloc] init];


### PR DESCRIPTION
Setting the flag in the `startSession` method. Thoughts about better way to enable/disable this feature?