### PR TITLE
feat(exposure): implement vision object tracking for main face

### DIFF
--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -42,12 +42,14 @@
 @property(nonatomic, assign) BOOL canAppendBuffer;
 @property(nonatomic, assign) CMTime bufferTimestamp;
 @property(nonatomic, assign) Float64 maxDuration;
-@property(nonatomic, assign) CGPoint primaryFaceCenter;
-@property(nonatomic, assign) CGImagePropertyOrientation facialTrackingOrientation;
 
+@property(nonatomic, strong) VNSequenceRequestHandler *trackingHandler;
+@property(nonatomic, assign) CGImagePropertyOrientation facialTrackingOrientation;
 @property(nonatomic, strong) CAShapeLayer *faceRect;
 @property(nonatomic, strong) CAShapeLayer *exposureSquare;
-@property(nonatomic, strong) VNFaceObservation *mainFace;
+@property(nonatomic, strong) VNDetectedObjectObservation *mainFace;
+@property(nonatomic, assign) CGPoint primaryFaceCenter;
+
 
 - (id)initWithBridge:(RCTBridge *)bridge;
 - (void)updateType;

--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -12,7 +12,6 @@
 
 @class RNCamera;
 
-API_AVAILABLE(ios(11.0))
 @interface RNCamera : UIView <AVCaptureMetadataOutputObjectsDelegate, RNFaceDetectorDelegate, AVCaptureVideoDataOutputSampleBufferDelegate>
 
 @property(nonatomic, strong) dispatch_queue_t sessionQueue;
@@ -44,11 +43,11 @@ API_AVAILABLE(ios(11.0))
 @property(nonatomic, assign) CMTime bufferTimestamp;
 @property(nonatomic, assign) Float64 maxDuration;
 
-@property(nonatomic, strong) VNSequenceRequestHandler *trackingHandler;
+@property(nonatomic, strong) VNSequenceRequestHandler *trackingHandler API_AVAILABLE(ios(11.0));
 @property(nonatomic, assign) CGImagePropertyOrientation facialTrackingOrientation;
 @property(nonatomic, strong) CAShapeLayer *faceRect;
 @property(nonatomic, strong) CAShapeLayer *exposureSquare;
-@property(nonatomic, strong) VNDetectedObjectObservation *mainFace;
+@property(nonatomic, strong) VNDetectedObjectObservation *mainFace API_AVAILABLE(ios(11.0));
 @property(nonatomic, assign) CGPoint mainFaceCenter;
 
 - (id)initWithBridge:(RCTBridge *)bridge;

--- a/ios/RN/RNCamera.h
+++ b/ios/RN/RNCamera.h
@@ -12,6 +12,7 @@
 
 @class RNCamera;
 
+API_AVAILABLE(ios(11.0))
 @interface RNCamera : UIView <AVCaptureMetadataOutputObjectsDelegate, RNFaceDetectorDelegate, AVCaptureVideoDataOutputSampleBufferDelegate>
 
 @property(nonatomic, strong) dispatch_queue_t sessionQueue;
@@ -48,8 +49,7 @@
 @property(nonatomic, strong) CAShapeLayer *faceRect;
 @property(nonatomic, strong) CAShapeLayer *exposureSquare;
 @property(nonatomic, strong) VNDetectedObjectObservation *mainFace;
-@property(nonatomic, assign) CGPoint primaryFaceCenter;
-
+@property(nonatomic, assign) CGPoint mainFaceCenter;
 
 - (id)initWithBridge:(RCTBridge *)bridge;
 - (void)updateType;

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -495,7 +495,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     if (!faceDetectionReq.results.count) {
         self.mainFaceCenter = CGPointZero;
         #ifdef DEBUG
-            [self drawFaceRect:nil];
+        [self drawFaceRect:nil];
         #endif
         return;
     };
@@ -510,7 +510,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
         CGPoint scaledPoint = CGPointMake(self.mainFaceCenter.x * self.layer.bounds.size.width, (1-self.mainFaceCenter.y) * self.layer.bounds.size.height);
         CGPoint devicePoint = [self.previewLayer captureDevicePointOfInterestForPoint:scaledPoint];
         #ifdef DEBUG
-            [self drawFaceRect:self.mainFace];
+        [self drawFaceRect:self.mainFace];
         #endif
         [self setExposureAtPoint:devicePoint];
     });

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -509,10 +509,10 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     dispatch_sync(dispatch_get_main_queue(), ^() {
         CGPoint scaledPoint = CGPointMake(self.mainFaceCenter.x * self.layer.bounds.size.width, (1-self.mainFaceCenter.y) * self.layer.bounds.size.height);
         CGPoint devicePoint = [self.previewLayer captureDevicePointOfInterestForPoint:scaledPoint];
-#ifdef DEBUG
-        [self drawFaceRect:self.mainFace];
-#endif
-        [self setExposureAtPoint:devicePoint];
+        #ifdef DEBUG
+          [self drawFaceRect:self.mainFace];
+        #endif
+          [self setExposureAtPoint:devicePoint];
     });
 }
 
@@ -533,9 +533,9 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     VNTrackObjectRequest *trackRequest = [[VNTrackObjectRequest alloc] initWithDetectedObjectObservation:lastObservation completionHandler:^(VNRequest *request, NSError *error) {
         if (error == nil && request.results.count) {
             VNDetectedObjectObservation *observation = request.results.firstObject;
-#ifdef DEBUG
-            [self drawFaceRect:observation];
-#endif
+            #ifdef DEBUG
+              [self drawFaceRect:observation];
+            #endif
             self.mainFace = observation;
             self.mainFaceCenter = CGPointMake(CGRectGetMidX(observation.boundingBox), CGRectGetMidY(observation.boundingBox));
             return;

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -494,9 +494,9 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 
     if (!faceDetectionReq.results.count) {
         self.mainFaceCenter = CGPointZero;
-#ifdef DEBUG
-        [self drawFaceRect:nil];
-#endif
+        #ifdef DEBUG
+            [self drawFaceRect:nil];
+        #endif
         return;
     };
 
@@ -509,9 +509,9 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     dispatch_sync(dispatch_get_main_queue(), ^() {
         CGPoint scaledPoint = CGPointMake(self.mainFaceCenter.x * self.layer.bounds.size.width, (1-self.mainFaceCenter.y) * self.layer.bounds.size.height);
         CGPoint devicePoint = [self.previewLayer captureDevicePointOfInterestForPoint:scaledPoint];
-#ifdef DEBUG
-        [self drawFaceRect:self.mainFace];
-#endif
+        #ifdef DEBUG
+            [self drawFaceRect:self.mainFace];
+        #endif
         [self setExposureAtPoint:devicePoint];
     });
 }
@@ -534,9 +534,9 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
         if (error == nil && request.results.count) {
             VNDetectedObjectObservation *observation = request.results.firstObject;
             [self drawFaceRect:observation];
-#ifdef DEBUG
-            [self drawFaceRect:observation];
-#endif
+            #ifdef DEBUG
+                [self drawFaceRect:observation];
+            #endif
             self.mainFace = observation;
             self.mainFaceCenter = CGPointMake(CGRectGetMidX(observation.boundingBox), CGRectGetMidY(observation.boundingBox));
             return;

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -493,7 +493,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     [handler performRequests:@[faceDetectionReq] error:nil];
 
     if (!faceDetectionReq.results.count) {
-        self.primaryFaceCenter = CGPointZero;
+        self.mainFaceCenter = CGPointZero;
         [self drawFaceRect:nil];
 #ifdef DEBUG
         [self drawFaceRect:nil];
@@ -501,15 +501,23 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
         return;
     };
 
-    if (!self.canAppendBuffer || (self.canAppendBuffer && CGPointEqualToPoint(self.primaryFaceCenter, CGPointZero))) {
+//    if (!self.canAppendBuffer || (self.canAppendBuffer && CGPointEqualToPoint(self.primaryFaceCenter, CGPointZero))) {
+//        [self establishPrimaryFace:faceDetectionReq];
+//    } else {
+//        //        [self trackPrimaryFace:faceDetectionReq:self.primaryFaceCenter];
+//        [self trackPrimaryFace:sampleBuffer withFace:self.mainFace];
+//    }
+
+    if (CGPointEqualToPoint(self.mainFaceCenter, CGPointZero)) {
         [self establishPrimaryFace:faceDetectionReq];
+        NSLog(@"---establish");
     } else {
-        //        [self trackPrimaryFace:faceDetectionReq:self.primaryFaceCenter];
         [self trackPrimaryFace:sampleBuffer withFace:self.mainFace];
+        NSLog(@"---tracking");
     }
 
     dispatch_sync(dispatch_get_main_queue(), ^() {
-        CGPoint scaledPoint = CGPointMake(self.primaryFaceCenter.x * self.layer.bounds.size.width, (1-self.primaryFaceCenter.y) * self.layer.bounds.size.height);
+        CGPoint scaledPoint = CGPointMake(self.mainFaceCenter.x * self.layer.bounds.size.width, (1-self.mainFaceCenter.y) * self.layer.bounds.size.height);
         CGPoint devicePoint = [self.previewLayer captureDevicePointOfInterestForPoint:scaledPoint];
         [self drawFaceRect:self.mainFace];
 #ifdef DEBUG
@@ -524,42 +532,24 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     for (VNFaceObservation *observation in faceDetectionReq.results) {
         if (!observation) continue;
         float size = observation.boundingBox.size.height * observation.boundingBox.size.width;
-        if (CGPointEqualToPoint(self.primaryFaceCenter, CGPointZero) || size > primaryFaceSize) {
-            self.primaryFaceCenter = CGPointMake(CGRectGetMidX(observation.boundingBox), CGRectGetMidY(observation.boundingBox));
+        if (CGPointEqualToPoint(self.mainFaceCenter, CGPointZero) || size > primaryFaceSize) {
+            self.mainFaceCenter = CGPointMake(CGRectGetMidX(observation.boundingBox), CGRectGetMidY(observation.boundingBox));
             self.mainFace = observation;
             primaryFaceSize = size;
         }
     }
 }
 
-//- (void)trackPrimaryFace:(VNDetectFaceRectanglesRequest*)faceDetectionReq :(CGPoint)primaryFace  API_AVAILABLE(ios(11.0)){
-//    double smallestDist = INFINITY;
-//    for (VNFaceObservation *observation in faceDetectionReq.results) {
-//        CGPoint center = CGPointMake(CGRectGetMidX(observation.boundingBox), CGRectGetMidY(observation.boundingBox));
-//        double distX = (primaryFace.x - center.x);
-//        double distY = (primaryFace.y - center.y);
-//        double dist = sqrt(distX * distX + distY * distY);
-//
-//        if (dist < smallestDist) {
-//            smallestDist = dist;
-//            self.mainFace = observation;
-//            self.primaryFaceCenter = center;
-//        }
-//    }
-//}
-
-- (void)trackPrimaryFace:(CMSampleBufferRef)sampleBuffer withFace:(VNDetectedObjectObservation*)mainFace  API_AVAILABLE(ios(11.0)){
-    VNTrackObjectRequest *trackRequest = [[VNTrackObjectRequest alloc] initWithDetectedObjectObservation:mainFace completionHandler:^(VNRequest *_Nonnull request, NSError *_Nullable error) {
+- (void)trackPrimaryFace:(CMSampleBufferRef)sampleBuffer withFace:(VNDetectedObjectObservation*)lastObservation  API_AVAILABLE(ios(11.0)){
+    VNTrackObjectRequest *trackRequest = [[VNTrackObjectRequest alloc] initWithDetectedObjectObservation:lastObservation completionHandler:^(VNRequest *request, NSError *error) {
         if (error == nil && request.results.count) {
-            NSLog(@"%@", request.results.firstObject);
             VNDetectedObjectObservation *observation = request.results.firstObject;
             [self drawFaceRect:observation];
             self.mainFace = observation;
-            self.primaryFaceCenter = CGPointMake(CGRectGetMidX(observation.boundingBox), CGRectGetMidY(observation.boundingBox));
+            self.mainFaceCenter = CGPointMake(CGRectGetMidX(observation.boundingBox), CGRectGetMidY(observation.boundingBox));
             return;
         }
-        self.primaryFaceCenter = CGPointZero;
-
+        self.mainFaceCenter = CGPointZero;
     }];
     CVPixelBufferRef pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
     CIImage *image = [CIImage imageWithCVPixelBuffer:pixelBuffer];
@@ -579,7 +569,6 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
         if (observation == nil) {
             return;
         }
-
         CGRect boundingBox = observation.boundingBox;
         CGSize size = CGSizeMake(boundingBox.size.width * self.layer.bounds.size.width, boundingBox.size.height * self.layer.bounds.size.height);
         CGPoint origin = CGPointMake(boundingBox.origin.x * self.layer.bounds.size.width, (1-boundingBox.origin.y) * self.layer.bounds.size.height - size.height);
@@ -615,7 +604,9 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 #if TARGET_IPHONE_SIMULATOR
     return;
 #endif
+
     self.canAppendBuffer = NO;
+    self.trackingHandler = [[VNSequenceRequestHandler alloc] init];
 
     void (^orientationBlock)(void) = ^() {
         self.facialTrackingOrientation = [RNCameraUtils imageOrientationForInterfaceOrientation:[[UIApplication sharedApplication] statusBarOrientation] withDevicePosition:[self.videoCaptureDeviceInput device].position];

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -494,32 +494,21 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 
     if (!faceDetectionReq.results.count) {
         self.mainFaceCenter = CGPointZero;
-        [self drawFaceRect:nil];
 #ifdef DEBUG
         [self drawFaceRect:nil];
 #endif
         return;
     };
 
-//    if (!self.canAppendBuffer || (self.canAppendBuffer && CGPointEqualToPoint(self.primaryFaceCenter, CGPointZero))) {
-//        [self establishPrimaryFace:faceDetectionReq];
-//    } else {
-//        //        [self trackPrimaryFace:faceDetectionReq:self.primaryFaceCenter];
-//        [self trackPrimaryFace:sampleBuffer withFace:self.mainFace];
-//    }
-
-    if (CGPointEqualToPoint(self.mainFaceCenter, CGPointZero)) {
+    if (!self.canAppendBuffer || (self.canAppendBuffer && CGPointEqualToPoint(self.mainFaceCenter, CGPointZero))) {
         [self establishPrimaryFace:faceDetectionReq];
-        NSLog(@"---establish");
     } else {
         [self trackPrimaryFace:sampleBuffer withFace:self.mainFace];
-        NSLog(@"---tracking");
     }
 
     dispatch_sync(dispatch_get_main_queue(), ^() {
         CGPoint scaledPoint = CGPointMake(self.mainFaceCenter.x * self.layer.bounds.size.width, (1-self.mainFaceCenter.y) * self.layer.bounds.size.height);
         CGPoint devicePoint = [self.previewLayer captureDevicePointOfInterestForPoint:scaledPoint];
-        [self drawFaceRect:self.mainFace];
 #ifdef DEBUG
         [self drawFaceRect:self.mainFace];
 #endif
@@ -544,7 +533,9 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     VNTrackObjectRequest *trackRequest = [[VNTrackObjectRequest alloc] initWithDetectedObjectObservation:lastObservation completionHandler:^(VNRequest *request, NSError *error) {
         if (error == nil && request.results.count) {
             VNDetectedObjectObservation *observation = request.results.firstObject;
+#ifdef DEBUG
             [self drawFaceRect:observation];
+#endif
             self.mainFace = observation;
             self.mainFaceCenter = CGPointMake(CGRectGetMidX(observation.boundingBox), CGRectGetMidY(observation.boundingBox));
             return;

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -495,16 +495,16 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     if (!faceDetectionReq.results.count) {
         self.primaryFaceCenter = CGPointZero;
         [self drawFaceRect:nil];
-        #ifdef DEBUG
+#ifdef DEBUG
         [self drawFaceRect:nil];
-        #endif
+#endif
         return;
     };
 
     if (!self.canAppendBuffer || (self.canAppendBuffer && CGPointEqualToPoint(self.primaryFaceCenter, CGPointZero))) {
         [self establishPrimaryFace:faceDetectionReq];
     } else {
-//        [self trackPrimaryFace:faceDetectionReq:self.primaryFaceCenter];
+        //        [self trackPrimaryFace:faceDetectionReq:self.primaryFaceCenter];
         [self trackPrimaryFace:sampleBuffer withFace:self.mainFace];
     }
 
@@ -512,9 +512,9 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
         CGPoint scaledPoint = CGPointMake(self.primaryFaceCenter.x * self.layer.bounds.size.width, (1-self.primaryFaceCenter.y) * self.layer.bounds.size.height);
         CGPoint devicePoint = [self.previewLayer captureDevicePointOfInterestForPoint:scaledPoint];
         [self drawFaceRect:self.mainFace];
-        #ifdef DEBUG
-          [self drawFaceRect:self.mainFace];
-        #endif
+#ifdef DEBUG
+        [self drawFaceRect:self.mainFace];
+#endif
         [self setExposureAtPoint:devicePoint];
     });
 }
@@ -548,11 +548,11 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 //    }
 //}
 
-- (void)trackPrimaryFace:(CMSampleBufferRef)sampleBuffer withFace:(VNDetectedObjectObservation)mainFace  API_AVAILABLE(ios(11.0)){
+- (void)trackPrimaryFace:(CMSampleBufferRef)sampleBuffer withFace:(VNDetectedObjectObservation*)mainFace  API_AVAILABLE(ios(11.0)){
     VNTrackObjectRequest *trackRequest = [[VNTrackObjectRequest alloc] initWithDetectedObjectObservation:mainFace completionHandler:^(VNRequest *_Nonnull request, NSError *_Nullable error) {
         if (error == nil && request.results.count) {
             NSLog(@"%@", request.results.firstObject);
-            VNDetectedObjectObservation observation = request.results.firstObject;
+            VNDetectedObjectObservation *observation = request.results.firstObject;
             [self drawFaceRect:observation];
             self.mainFace = observation;
             self.primaryFaceCenter = CGPointMake(CGRectGetMidX(observation.boundingBox), CGRectGetMidY(observation.boundingBox));
@@ -573,7 +573,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     [self.trackingHandler performRequests:observationRequest onCIImage:orientedImage error:nil];
 }
 
--(void)drawFaceRect:(VNFaceObservation *)observation  API_AVAILABLE(ios(11.0)){
+-(void)drawFaceRect:(VNDetectedObjectObservation *)observation  API_AVAILABLE(ios(11.0)){
     dispatch_async(dispatch_get_main_queue(), ^{
         [self.faceRect removeFromSuperlayer];
         if (observation == nil) {

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -494,9 +494,9 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 
     if (!faceDetectionReq.results.count) {
         self.mainFaceCenter = CGPointZero;
-#ifdef DEBUG
-        [self drawFaceRect:nil];
-#endif
+        #ifdef DEBUG
+          [self drawFaceRect:nil];
+        #endif
         return;
     };
 

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -494,9 +494,9 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 
     if (!faceDetectionReq.results.count) {
         self.mainFaceCenter = CGPointZero;
-        #ifdef DEBUG
-          [self drawFaceRect:nil];
-        #endif
+#ifdef DEBUG
+        [self drawFaceRect:nil];
+#endif
         return;
     };
 
@@ -509,10 +509,10 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     dispatch_sync(dispatch_get_main_queue(), ^() {
         CGPoint scaledPoint = CGPointMake(self.mainFaceCenter.x * self.layer.bounds.size.width, (1-self.mainFaceCenter.y) * self.layer.bounds.size.height);
         CGPoint devicePoint = [self.previewLayer captureDevicePointOfInterestForPoint:scaledPoint];
-        #ifdef DEBUG
-          [self drawFaceRect:self.mainFace];
-        #endif
-          [self setExposureAtPoint:devicePoint];
+#ifdef DEBUG
+        [self drawFaceRect:self.mainFace];
+#endif
+        [self setExposureAtPoint:devicePoint];
     });
 }
 
@@ -533,9 +533,10 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     VNTrackObjectRequest *trackRequest = [[VNTrackObjectRequest alloc] initWithDetectedObjectObservation:lastObservation completionHandler:^(VNRequest *request, NSError *error) {
         if (error == nil && request.results.count) {
             VNDetectedObjectObservation *observation = request.results.firstObject;
-            #ifdef DEBUG
-              [self drawFaceRect:observation];
-            #endif
+            [self drawFaceRect:observation];
+#ifdef DEBUG
+            [self drawFaceRect:observation];
+#endif
             self.mainFace = observation;
             self.mainFaceCenter = CGPointMake(CGRectGetMidX(observation.boundingBox), CGRectGetMidY(observation.boundingBox));
             return;
@@ -598,15 +599,6 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 
     self.canAppendBuffer = NO;
     self.trackingHandler = [[VNSequenceRequestHandler alloc] init];
-
-    void (^orientationBlock)(void) = ^() {
-        self.facialTrackingOrientation = [RNCameraUtils imageOrientationForInterfaceOrientation:[[UIApplication sharedApplication] statusBarOrientation] withDevicePosition:[self.videoCaptureDeviceInput device].position];
-    };
-    if ([NSThread isMainThread]) {
-        orientationBlock();
-    } else {
-        dispatch_sync(dispatch_get_main_queue(), orientationBlock);
-    }
 
     dispatch_async(self.sessionQueue, ^{
         if (self.presetCamera == AVCaptureDevicePositionUnspecified) {
@@ -709,6 +701,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
             [self updateExposureMode];
             [self.previewLayer.connection setVideoOrientation:orientation];
             [self _updateMetadataObjectsToRecognize];
+            self.facialTrackingOrientation = [RNCameraUtils imageOrientationForInterfaceOrientation:[[UIApplication sharedApplication] statusBarOrientation] withDevicePosition:[self.videoCaptureDeviceInput device].position];
         }
 
         [self.session commitConfiguration];

--- a/ios/RN/RNCameraUtils.m
+++ b/ios/RN/RNCameraUtils.m
@@ -62,33 +62,32 @@
 
 + (CGImagePropertyOrientation)imageOrientationForInterfaceOrientation:(UIInterfaceOrientation)orientation withDevicePosition:(AVCaptureDevicePosition)position
 {
-    if (position == AVCaptureDevicePositionBack) {
+    if (position == AVCaptureDevicePositionFront) {
         switch (orientation) {
             case UIInterfaceOrientationPortrait:
-                return kCGImagePropertyOrientationRight;
+                return kCGImagePropertyOrientationLeftMirrored;
             case UIInterfaceOrientationPortraitUpsideDown:
-                return kCGImagePropertyOrientationLeft;
+                return kCGImagePropertyOrientationRightMirrored;
             case UIInterfaceOrientationLandscapeLeft:
-                return kCGImagePropertyOrientationDown;
+                return kCGImagePropertyOrientationUpMirrored;
             case UIInterfaceOrientationLandscapeRight:
-                return kCGImagePropertyOrientationUp;
+                return kCGImagePropertyOrientationDownMirrored;
             default:
                 return 0;
         }
     }
     switch (orientation) {
         case UIInterfaceOrientationPortrait:
-            return kCGImagePropertyOrientationLeftMirrored;
+            return kCGImagePropertyOrientationRight;
         case UIInterfaceOrientationPortraitUpsideDown:
-            return kCGImagePropertyOrientationRightMirrored;
+            return kCGImagePropertyOrientationLeft;
         case UIInterfaceOrientationLandscapeLeft:
-            return kCGImagePropertyOrientationUpMirrored;
+            return kCGImagePropertyOrientationDown;
         case UIInterfaceOrientationLandscapeRight:
-            return kCGImagePropertyOrientationDownMirrored;
+            return kCGImagePropertyOrientationUp;
         default:
             return 0;
     }
-
 }
 
 + (float)temperatureForWhiteBalance:(RNCameraWhiteBalance)whiteBalance

--- a/ios/RN/RNCameraUtils.m
+++ b/ios/RN/RNCameraUtils.m
@@ -62,32 +62,33 @@
 
 + (CGImagePropertyOrientation)imageOrientationForInterfaceOrientation:(UIInterfaceOrientation)orientation withDevicePosition:(AVCaptureDevicePosition)position
 {
-    if (position == AVCaptureDevicePositionFront) {
+    if (position == AVCaptureDevicePositionBack) {
         switch (orientation) {
             case UIInterfaceOrientationPortrait:
-                return kCGImagePropertyOrientationLeftMirrored;
+                return kCGImagePropertyOrientationRight;
             case UIInterfaceOrientationPortraitUpsideDown:
-                return kCGImagePropertyOrientationRightMirrored;
+                return kCGImagePropertyOrientationLeft;
             case UIInterfaceOrientationLandscapeLeft:
-                return kCGImagePropertyOrientationUpMirrored;
+                return kCGImagePropertyOrientationDown;
             case UIInterfaceOrientationLandscapeRight:
-                return kCGImagePropertyOrientationDownMirrored;
+                return kCGImagePropertyOrientationUp;
             default:
                 return 0;
         }
     }
     switch (orientation) {
         case UIInterfaceOrientationPortrait:
-            return kCGImagePropertyOrientationRight;
+            return kCGImagePropertyOrientationLeftMirrored;
         case UIInterfaceOrientationPortraitUpsideDown:
-            return kCGImagePropertyOrientationLeft;
+            return kCGImagePropertyOrientationRightMirrored;
         case UIInterfaceOrientationLandscapeLeft:
-            return kCGImagePropertyOrientationDown;
+            return kCGImagePropertyOrientationUpMirrored;
         case UIInterfaceOrientationLandscapeRight:
-            return kCGImagePropertyOrientationUp;
+            return kCGImagePropertyOrientationDownMirrored;
         default:
             return 0;
     }
+
 }
 
 + (float)temperatureForWhiteBalance:(RNCameraWhiteBalance)whiteBalance


### PR DESCRIPTION
Ok...I think this is ready. Wrestled with `[self.videoCaptureDeviceInput device].position` sometimes returning `AVCaptureDevicePositionUnspecified` when it is called in `startSession`, leading to the incorrect orientation set for the tracking. I think this was due to the `initializeCaptureSessionInput` being called right before `startSession` with an async block to setup the camera. Moved the orientation setup block out of `startSession` and into the async block to ensure it happens after the device has been fully initialized. This seems to have fixed the issue, but definitely give this a spin on your end though.

Xcode was yelling at me for including ios11 only header definitions. It suggested adding `API_AVAILABLE(ios(11.0))` to the top, but my understanding is that this would require ios11 for all the declarations, rather than just selectively isolating the Vision types. Is there a better way to do this?

